### PR TITLE
fix(blog): Correct FlatSet

### DIFF
--- a/blog/blog/2022-09-20-clap4.md
+++ b/blog/blog/2022-09-20-clap4.md
@@ -320,7 +320,7 @@ values.
 Benefit
 - Removed some dependencies (`indexmap`, `hashbrown`)
 - Minimizing the number of containers means more reuse when they get monomorphized
-- Building on `Vec`s allow even more monomorphized reuse as a `FlatStr<Str>` is
+- Building on `Vec`s allow even more monomorphized reuse as a `FlatSet<Str>` is
   really just a `Vec<Str>`.  This is more acute for `FlatMap` since we store
   the keys and values separately.  A `FlatMap<Str, Vec<Str>>` is really a
   `(Vec<Str>, Vec<Vec<Str>>)`, allowing reuse between the key and value and any


### PR DESCRIPTION
Minor fix to reference `FlatSet`.