### PR TITLE
Make all commits into links to github

### DIFF
--- a/blog/blog/2022-09-20-clap4.md
+++ b/blog/blog/2022-09-20-clap4.md
@@ -142,7 +142,11 @@ Problems with the colored help
 - If the developer was providing additional ASCII-formatted content, the
   partial coloring is glaring
 
-In the short term, `6079a871`, `8315ba3d`, `e02648e6` starts us off with a more neutral color palette by
+In the short term,
+[`6079a871`](https://github.com/clap-rs/clap/commit/6079a871),
+[`8315ba3d`](https://github.com/clap-rs/clap/commit/8315ba3d),
+[`e02648e6`](https://github.com/clap-rs/clap/commit/8315ba3d)
+starts us off with a more neutral color palette by
 focusing on bold/underline, rather than colors.  Longer term, we need to allow
 users to customize the colors
 ([#3234](https://github.com/clap-rs/clap/issues/3234))
@@ -153,14 +157,15 @@ We plan to focus on this during clap 4.x.
 We then extended the styling to the usage line as well as the general structure
 of the help output.  This required dropping `textwrap` and included clean up
 that helped offset the extra code size from the extra formatting logic. This
-happened in `2e2b63fa..a6cb2e65`
+happened in [`2e2b63fa..a6cb2e65`](https://github.com/clap-rs/clap/compare/2e2b63fa..a6cb2e65)
 - Code size: 562.7KiB → 566.0 KiB (+3.3 KiB)
 - Lines of Code: 19,078 → 19,468 <span style="color:red">(+390)</span>
 
 A frequent point of confusion for users is that `-h` shows an abbreviated help
 and `--help` shows a detailed help.  `rg` and `bat` include messages in the
 output explaining the distinction.  I realized we could bake this directly into
-the description for `-h` and `--help`. This happened in `c1c269b4`
+the description for `-h` and `--help`. This happened in
+[`c1c269b4`](https://github.com/clap-rs/clap/commit/c1c269b4)
 - Code size: 567.1 KiB → 568.0 KiB (+0.9 KiB)
 - Lines of Code: 19,693 → 19,708 (+15)
 
@@ -171,31 +176,42 @@ reason for the usage in the first place.  We've changed the usage to never
 collapse positional arguments into `[ARGS]` as that seems to strike a nice
 balance.  Longer term, we should provide ways for users to force certain args
 to not be collapsed or to allow specialized usages per case in an `ArgGroup`.
-This happened in `f3c4bfd9..a1256a6e`
+This happened in [`f3c4bfd9..a1256a6e`](https://github.com/clap-rs/clap/compare/f3c4bfd9..a1256a6e)
 - Code size: 570.4 KiB → 567.1 KiB (-3.3 KiB)
 - Lines of Code: 19,631 → 19,628 (-3)
 
 We also
 - When looking at non-clap CLIs to avoid any [NIH syndrome](https://en.wikipedia.org/wiki/Not_invented_here), the ALL CAPS headers
- started bothering me more and more, so we switched to title case in `9b23a09f`.
+ started bothering me more and more, so we switched to title case in
+ [`9b23a09f`](https://github.com/clap-rs/clap/commit/9b23a09f).
  I know some users appreciated the man page style formatting but I'm hoping this
  will be a more polished look for people less familiar with man pages.
 - When looking at the help after this change, it just felt off seeing
  "Subcommand".  "Subcommand" is just a more specific case for "Command" and its
  rare to see others do this, so I went ahead and switched to "Command" in
- `42c94384`.
+ [`42c94384`](https://github.com/clap-rs/clap/commit/42c94384).
 - In looking at other CLIs, I also noticed they tend to put subcommands front and
  center.  This makes sense since the parent commands are generally not usable on
- their own.  We followed suit in `83d6add9`.  One problem with putting subcommands
+ their own.  We followed suit in
+ [`83d6add9`](https://github.com/clap-rs/clap/commit/83d6add9).
+ One problem with putting subcommands
  first is when the help output scrolls off the screen.  This highlights an
  existing problem with clap help output.  We have started [investigating adding
  a pager to help output](https://github.com/clap-rs/clap/issues/4201).
-- Made usage / arg displays more consistent in `02db3043`, `df76168`, `76dd3a18`
-- Removed name/version/author from the default `Command::help_template` as it is mostly redundant in `65b5b5f7`
-- Further condensed `--help` output by switching the template to have Usage on one line in `9a645d2d`
-- Even further condense `-h` with `next_line_help` by removing the blank lines between arguments in `bbb6c38b`
-- Aim for horizontal density by changing indentation from the less common 4 spaces to the more common 2 spaces in `65c28978..c95c9f2f`
-- Respect `COLUMNS` when we can't detect terminal width in `1466cd5f..79321f25`
+- Made usage / arg displays more consistent in
+  [`02db3043`](https://github.com/clap-rs/clap/commit/02db3043),
+  [`df76168`](https://github.com/clap-rs/clap/commit/df76168),
+  [`76dd3a18`](https://github.com/clap-rs/clap/commit/76dd3a18)
+- Removed name/version/author from the default `Command::help_template` as it is mostly redundant in
+  [`65b5b5f7`](https://github.com/clap-rs/clap/commit/65b5b5f7)
+- Further condensed `--help` output by switching the template to have Usage on one line in
+  [`9a645d2d`](https://github.com/clap-rs/clap/commit/9a645d2d)
+- Even further condense `-h` with `next_line_help` by removing the blank lines between arguments in
+  [`bbb6c38b`](https://github.com/clap-rs/clap/commit/bbb6c38b)
+- Aim for horizontal density by changing indentation from the less common 4 spaces to the more common 2 spaces in
+  [`65c28978..c95c9f2f`](https://github.com/clap-rs/clap/compare/65c28978..c95c9f2f)
+- Respect `COLUMNS` when we can't detect terminal width in 
+  [`1466cd5f..79321f25`](https://github.com/clap-rs/clap/compare/1466cd5f..79321f25)
 
 <a id="more-specific-derive-attributes"></a>
 ### More Specific Derive Attributes
@@ -246,13 +262,21 @@ relate (
 `#[arg(...)]`, and `#[value(...)]` attributes, code will be clearer, the derive
 will be easier to use, and we can expand on the capabilities of the derive API.
 
-This happened in `2f4e42f2..ba5eec31` and `20ba828f..f5138629` and as they are
+This happened in
+[`2f4e42f2..ba5eec31`](https://github.com/clap-rs/clap/compare/2f4e42f2..ba5eec31)
+and
+[`20ba828f..f5138629` ](https://github.com/clap-rs/clap/compare/20ba828f..f5138629)
+and as they are
 focusing on a code generating, they should have negligible impact on code size
 either way.
 
 This also provided an opportunity for us to do some much needed cleanup of `clap_derive`, including
-- Reducing duplicate parsing in `a20c67c8..3ec2f0f7`
-- Improved error and deprecation reporting in `ebe181ac..20ba828f`, `f5138629..7ed7f71a`, `7ed7f71a..088b396d`
+- Reducing duplicate parsing in
+  [`a20c67c8..3ec2f0f7`](https://github.com/clap-rs/clap/compare/a20c67c8..3ec2f0f7)
+- Improved error and deprecation reporting in
+  [`ebe181ac..20ba828f`](https://github.com/clap-rs/clap/compare/ebe181ac..20ba828f),
+  [`f5138629..7ed7f71a`](https://github.com/clap-rs/clap/compare/f5138629..7ed7f71a),
+  [`7ed7f71a..088b396d`](https://github.com/clap-rs/clap/compare/7ed7f71a..088b396d)
 
 <a id="num-args"></a>
 ### `num_args`
@@ -298,7 +322,10 @@ The most fundamental changes were the introduction of
 - [ArgAction](https://docs.rs/clap/latest/clap/enum.ArgAction.html) which provided more transparency into clap's behavior
 - [Arg::value_parser](https://docs.rs/clap/latest/clap/builder/struct.Arg.html#method.value_parser) which made clap's validation more open ended, allowing the deprecation of a lot of built-in validators
 
-Removing deprecated APIs were done in `16bd7599..017b87ab` ([#3963](https://github.com/clap-rs/clap/pull/3963)) and `017b87ab..ee06707c`
+Removing deprecated APIs were done in
+[`16bd7599..017b87ab` ](https://github.com/clap-rs/clap/compare/16bd7599..017b87ab)
+([#3963](https://github.com/clap-rs/clap/pull/3963)) and
+[`017b87ab..ee06707c`](https://github.com/clap-rs/clap/compare/017b87ab..ee06707c)
 - Code size: 604.6 KiB → 564.5 KiB <span style="color:green">(-40.1 KiB)</span>
 - Lines of Code: 23,254 → 17,854 <span style="color:green">(-5,400)</span>
 
@@ -326,7 +353,8 @@ Benefit
   `(Vec<Str>, Vec<Vec<Str>>)`, allowing reuse between the key and value and any
   `FlatSet<Str>` or `Vec<Str>` in the code base.
 
-This happened in `b344f1cf..084a6dff`
+This happened in
+[`b344f1cf..084a6dff`](https://github.com/clap-rs/clap/compare/b344f1cf..084a6dff)
 - Code size: 561.2 KiB → 525.2 KiB  <span style="color:green">(-36 KiB)</span>
 - Lines of Code: 17,789 → 18,075  (+286)
 
@@ -343,7 +371,7 @@ My hope is we can re-work this data structure in
 To see how much this will help reduce binary size, I switched to a straight
 `String` when the `color` feature flag is disabled.
 
-This happened in `e75da2f8`
+This happened in [`e75da2f8`](https://github.com/clap-rs/clap/commit/e75da2f8)
 - Code size: 542.7 KiB → 542.4 KiB (-0.3 KiB)
 - Code size without `color`: 533.6 KiB → 518.2 KiB <span style="color:green">(-15.4 KiB)</span>
 - Lines of Code: 20,426 → 20,470  (+34)
@@ -354,7 +382,9 @@ an example of using traits for reducing size rather than throwing in more
 feature flags which can be harder to maintain and harder for a developer to discover
 and use well.
 
-This happened in `956789c3..d219c69c`.  An application that switches from the
+This happened in
+[`956789c3..d219c69c`](https://github.com/clap-rs/clap/compare/956789c3..d219c69c).
+An application that switches from the
 "rich" to the "null" formatter dropped code size by <span style="color:green">6 KiB</span>.  This won't show up
 in our usual metrics as this is opt-in and the example we are using for
 measuring does not opt-in.
@@ -363,19 +393,21 @@ When adopting `StyledStr`, we also needed some behavior that `textwrap` didn't
 seem to provide, so we re-implemented a subset that fit our needs (incremental
 wrapping).
 
-This happened in `37f2efb0`
+This happened in [`37f2efb0`](https://github.com/clap-rs/clap/commit/37f2efb0)
 - Code size: 577.6 KiB → 565.1 KiB <span style="color:green">(-12.5 KiB)</span>
 - Lines of Code: 19,250 → 19,483  (+233)
 
 In cleaning up `clap_derive`, we found some redundant generated code that we
-cleaned up in `0b5f95e3`.  Our usual benchmark doesn't cover this case.  I ran
+cleaned up in [`0b5f95e3`](https://github.com/clap-rs/clap/commit/0b5f95e3).
+Our usual benchmark doesn't cover this case.  I ran
 another one and didn't see any noticeable change, so congrats to the compiler
 optimizing it?
 
 Looking for another way to break down where all of the code size for clap comes
 from, I split out auto-generated `help`, auto-generated `usage`, and `error-context` features.
 
-This happened in `94c5802a..c26e7fd6`
+This happened in
+[`94c5802a..c26e7fd6`](https://github.com/clap-rs/clap/compare/94c5802a..c26e7fd6)
 - Code size: 542.9 KiB → 544.3 KiB (+2.6 KiB)
 - Lines of Code: 20,312 → 20,653  (+341)
 
@@ -422,15 +454,15 @@ The use of `impl Into<Str>` did run into problems with the few places we had
 what type it was coming from, so we created the `IntoResettable` trait to
 resolve these ambiguities.
 
-`a5494573..5950c4b9`
+[`a5494573..5950c4b9`](https://github.com/clap-rs/clap/compare/a5494573..5950c4b9)
 - Code size: 525.2 KiB → 553.4 KiB <span style="color:red">(+28.2 KiB)</span>
 - Lines of Code: 18,075 → 18,460 <span style="color:red">(+385)</span>
 
-`e81b1aac..c6b8a7ba`
+[`e81b1aac..c6b8a7ba`](https://github.com/clap-rs/clap/compare/e81b1aac..c6b8a7ba)
 - Code size: 553.4 KiB → 565.7 KiB <span style="color:red">(+12.3 KiB)</span>
 - Lines of Code: 18,524 → 18,873 <span style="color:red">(+349)</span>
 
-`d4ec9ca5..956789c3`
+[`d4ec9ca5..956789c3`](https://github.com/clap-rs/clap/compare/d4ec9ca5..956789c3)
 - Code size: 565.7 KiB → 563.6 KiB (-2.1 KiB)
 - Lines of code: 18,876 → 18,883 (+7)
 
@@ -442,13 +474,13 @@ accepts only `&'static str` by default and the `string` feature flag changes
 the API to accept `String`s as well, restoring most of the code size and runtime
 performance from before we made any of these changes.
 
-`1365b088..6dc8c994`
+[`1365b088..6dc8c994`](https://github.com/clap-rs/clap/compare/1365b088..6dc8c994)
 - Code size: 567.2 KiB → 541.1 KiB <span style="color:green">(-26.1 KiB)</span>
 - Lines of code: 20,233 → 20,278 (+45)
 
 As I mentioned, we have to support some fields being resettable.  We've made
 this more consistent by allowing nearly all fields to be reset in
-`ee387c66..7ee121a2`
+[`ee387c66..7ee121a2`](https://github.com/clap-rs/clap/compare/ee387c66..7ee121a2)
 
 <a id="removing-implicit-version-help-behavior"></a>
 ### Removing Implicit Version/Help Behavior
@@ -472,11 +504,13 @@ Now, things are simplified down to
   `cmd.disable_help_flag(true)` and provide your own flag.  For your custom
   help flag to show clap's help automatically, call `arg.action(ArgAction::Help)`.
 
-Most changes happened between `0129d99f..6bc8dfd3`
+Most changes happened between
+[`0129d99f..6bc8dfd3`](https://github.com/clap-rs/clap/compare/0129d99f..6bc8dfd3)
 - Code size: 563.5 KiB → 561.6 KiB (-1.9 KiB)
 - Lines of Code: 17,944 → 17,789 (-155)
 
-Specifically `f70ebe89` is where almost all of the parse speed gains happened
+Specifically [`f70ebe89`](https://github.com/clap-rs/clap/commit/f70ebe89)
+is where almost all of the parse speed gains happened
 between clap v3 and clap v4, returning clap back to clap v2's performance.
 
 <a id="storing-ids-for-arggroup"></a>
@@ -502,7 +536,7 @@ argument, we are storing its arg `Id` in the `ArgGroup`, reducing the number of
 allocations involved (since an `Id` might not even be on the heap) and making
 it easier to make programmatic decisions about the argument.
 
-This happened in `41be1bed`
+This happened in [`41be1bed`](https://github.com/clap-rs/clap/commit/41be1bed)
 - Code size: 550.0 KiB → 550.7 KiB (+0.7 KiB)
 - Lines of Code: 18,057 → 18,062 (+5)
 
@@ -528,7 +562,8 @@ we decided to not move forward with that route.  This meant we could go back to
 strings, especially with our previous lifetime changes, and make it fairly
 ergonomic to allow people to enumerate the arguments that were parsed.
 
-This happened in `7486a0b4` though it was dependent on a batch of the lifetime
+This happened in [`7486a0b4` ](https://github.com/clap-rs/clap/commit/7486a0b4)
+though it was dependent on a batch of the lifetime
 work mentioned earlier.  See the lifetime-removal work for metrics.
 
 <a id="non-bool-flags"></a>
@@ -568,7 +603,8 @@ within clap to accomplish this:
     to be parsed by the value_parser
   - Adapt a `bool` value parser via `ValueParser::map`
 
-This happened between `5950c4b9..e81b1aac`
+This happened between
+[`5950c4b9..e81b1aac`](https://github.com/clap-rs/clap/compare/5950c4b9..e81b1aac)
 - Code size: 553.4 KiB → 553.4 KiB (0)
 - Lines of Code: 18,460 → 18,524 (+64)
 
@@ -592,7 +628,8 @@ deprecated all of the `Command` variants of these settings.  We then did
 similar for a closely related setting, `Command::trailing_var_args` which
 brings it inline with its related `Arg::last`.
 
-This happened in `f731ce70..f97670ac`
+This happened in
+[`f731ce70..f97670ac`](https://github.com/clap-rs/clap/compare/f731ce70..f97670ac)
 - Code size: 568.4 KiB → 572.1 KiB (+3.7 KiB)
 - Lines of Code: 19,900 → 20,041 (+241)
 
@@ -659,7 +696,8 @@ completions more featureful, less buggy, and more consistent across shells.
 <a id="methodology"></a>
 ## Methodology
 
-- `master` as of `16bd7599..c26e7fd6`
+- `master` as of
+  [`16bd7599..c26e7fd6`](https://github.com/clap-rs/clap/compare/16bd7599..c26e7fd6)
 - Baseline is a simple program that reads all arguments and prints them back out
 - API Surface:
   - `rg -U '\([\s]*(mut )?self,'` for `Command`, `Arg`, and `ArgGroup`


### PR DESCRIPTION
I made all commit hashes and commit ranges in your clap 4.0 blogpost into links to github.

Maybe you find this useful.